### PR TITLE
style: refactor main to import wrapping App.tsx

### DIFF
--- a/login-flow.md
+++ b/login-flow.md
@@ -1,0 +1,40 @@
+# FLOW OF USER-LOGIN
+
+Flow will take inspiration from the process used in the [se_project_react](../../../../aaron/OneDrive/Documents/TripleTen/Project%20Materials/Project-Files/se_project_react/se_project_react/) project.
+
+User will be logged in upon loading the page when there is a valid token available. If no token is found, return from the `useEffect` and continue with program flow. User will have to log in.
+
+When page is loaded, a `useEffect()` with no dependencies is run.
+
+Consider the following `useEffect()` call:
+
+    useEffect(() => {
+        const token = getToken();
+        if (!token) return;
+
+        auth
+        .getUserInfo(token)
+        .then((res) => {
+            const { name, email, avatar, _id } = res;
+            setIsLoggedIn(true);
+            setUserData({ name, email, avatar, _id });
+            navigate("//");
+        })
+        .catch(auth.responseError);
+    }, []);
+
+It uses calls to the following methods which are defined below:
+
+- `getToken()`
+- `auth.getUserInfo(token)`
+- `setIsLoggedIn(true)` useState function
+- `setUserData({name, email, avatar, _id})` useState function
+- `navigate` object which uses the `useNavigate()` hook
+
+## `getToken()`
+
+Found in [token.js](../../../../aaron/OneDrive/Documents/TripleTen/Project%20Materials/Project-Files/se_project_react/se_project_react/src/utils/token.js)
+
+## `auth.getUserInfo(token)`
+
+Found in [auth.js](../../../../aaron/OneDrive/Documents/TripleTen/Project%20Materials/Project-Files/se_project_react/se_project_react/src/utils/auth.js)

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Routes, Route } from "react-router";
+import Dashboard from "./Dashboard/Dashboard";
+import Login from "./login-route";
+import UserManagement from "../routes/user-management/user-management";
+
+/**
+ * All routing and functionality goes here. Any functionality that runs
+ * on app load will go here.
+ */
+function App() {
+  // useStates and useEffects go here
+  return (
+    <main className="flex-1 bg-zinc-950 ">
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/user-management" element={<UserManagement />} />
+        <Route path="/login" element={<Login />} />
+      </Routes>
+    </main>
+  );
+}
+
+export default App;

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -6,20 +6,22 @@ import BreadcrumbHeader from "../BreadcrumbHeader/BreadcrumbHeader";
 
 const Dashboard: React.FC = () => {
   return (
-    <div className="flex h-screen overflow-hidden">
-      <Sidebar />
-      <main className="flex-1 p-6 overflow-y-auto bg-zinc-950">
-        <BreadcrumbHeader section="Overview" page="History" />
-        {/* Top row of 3 cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-          <DashCard />
-          <DashCard />
-          <DashCard />
-        </div>
+    <div className="flex h-screen">
+      <div className="flex h-screen overflow-hidden">
+        <Sidebar />
+        <main className="flex-1 p-6 overflow-y-auto bg-zinc-950">
+          <BreadcrumbHeader section="Overview" page="History" />
+          {/* Top row of 3 cards */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+            <DashCard />
+            <DashCard />
+            <DashCard />
+          </div>
 
-        {/* Main content area */}
-        <DashContent />
-      </main>
+          {/* Main content area */}
+          <DashContent />
+        </main>
+      </div>
     </div>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,33 +1,18 @@
 import { ApolloProvider } from "@apollo/client";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { BrowserRouter } from "react-router-dom";
 import "./global/default.css";
 import { client } from "./store";
 import { ThemeProvider } from "./components/theme-provider";
-import Login from "./components/login-route";
-import Dashboard from "./components/Dashboard/Dashboard";
-import UserManagement from "./routes/user-management/user-management";
+import App from "./components/App";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <ApolloProvider client={client}>
         <BrowserRouter>
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <div className="flex h-screen">
-                  <main className="flex-1 bg-zinc-950 ">
-                    <Dashboard />
-                  </main>
-                </div>
-              }
-            />
-            <Route path="/user-management" element={<UserManagement />} />
-            <Route path="/login" element={<Login />} />
-          </Routes>
+          <App />
         </BrowserRouter>
       </ApolloProvider>
     </ThemeProvider>


### PR DESCRIPTION
Moved all the component imports from `main.tsx` to a new component `App.tsx`, which is now the only component import in `main.tsx`. This will allow `main.tsx` to remain clean.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If there are changes to components, I have added / updated automated tests
- [x] I have made any necessary updates to Storybook to accompany these changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
